### PR TITLE
Feature/create relationship user to invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,9 +1,11 @@
 class Invoice < ApplicationRecord
   has_one_attached :pdf
+  belongs_to :user
 
   validates :invoice_number, presence: true, format: { with: /\A[a-zA-Z0-9]+\z/, message: "deve conter apenas letras e números!" }
   validates :purchase_date, presence: true
   validates :issue_date, presence: true
   validates :pdf, presence: true
-
+  validates :user_id, presence: true
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
 
   enum role: {user: 0, admin: 1}
+  has_many :invoices
 
   validates :name, presence: true, length: { minimum: 3, maximum: 50 }, format: { with: /\A[a-zA-Z\s]+\z/, message: "Utilize somente letras" } 
   # Include default devise modules. Others available are: 

--- a/db/migrate/20241008135622_add_user_to_invoices.rb
+++ b/db/migrate/20241008135622_add_user_to_invoices.rb
@@ -1,0 +1,5 @@
+class AddUserToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :invoices, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_01_004909) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_08_135622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_01_004909) do
     t.date "issue_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_invoices_on_user_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -103,5 +105,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_01_004909) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "invoices", "users"
   add_foreign_key "warranties", "products"
 end


### PR DESCRIPTION
## Descrição
Este Pull Request adiciona o relacionamento entre a model `Invoice` e a model `User`, onde cada `Invoice` pertence a um único `User` e um `User` pode ter nenhuma, uma ou várias `Invoice`. Essa mudança permite que as notas fiscais sejam associadas a seus respectivos usuários.

### Alterações feitas:
- Adição da coluna `user_id` a model `Invoice` para armazenar a referência ao usuário associado.
- Atualização da model `Invoice` para incluir a associação `belongs_to :user`.
- Atualização da model `User` para incluir a associação `has_many :invoices`.
- Adição de validações para garantir que o `user_id` não seja nulo.

### Como testar:
1. Execute as migrações para garantir que as alterações no banco de dados sejam aplicadas.
2. Crie alguns usuários e associe as notas fiscais a esses usuários.
3. Verifique se a associação está funcionando corretamente através do console Rails ou pelo sgbd de sua escolha.