### PR TITLE
Feature/i18n standardize permission msgs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,49 +1,11 @@
 class ApplicationController < ActionController::API
   before_action :authenticate_user!, unless: :devise_controller?
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_locale
 
   include DeviseTokenAuth::Concerns::SetUserByToken
   include Pundit::Authorization
-
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
-
-  private
-
-  def extract_locale_from_accept_language_header
-    if request.env['HTTP_ACCEPT_LANGUAGE']
-      language = request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}(?:-[A-Z]{2})?/).first
-      return language if I18n.available_locales.include?(language&.to_sym)
-    end
-    nil
-  end
-
-  def record_not_found(exception)
-    model_name = exception.model.constantize.model_name.human
-    render json: { error: I18n.t('errors.not_found', model: model_name) }, status: :not_found
-  end
-
-  def render_deletion_message(model_name)
-    render json: { message: I18n.t('default_messages.deleted', model: model_name) }, status: :ok
-  end
-
-  def render_unprocessable_entity_response(exception)
-    render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
-  end
-
-  def set_locale
-    locale = extract_locale_from_accept_language_header || I18n.default_locale
-    Rails.logger.info "Locale set to #{locale}"
-    I18n.locale = locale
-  end
-
-  def user_not_authorized(exception)
-    policy_name = exception.policy.class.to_s.underscore
-    render json: { error: I18n.t("errors.#{policy_name}.#{exception.query}") },
-           status: :forbidden
-  end
+  include LocaleHandler
+  include ErrorHandler
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,10 @@
 class ApplicationController < ActionController::API
-  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_locale
 
   include DeviseTokenAuth::Concerns::SetUserByToken
   include Pundit::Authorization
-
-  before_action :authenticate_user!, unless: :devise_controller?
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -13,19 +12,37 @@ class ApplicationController < ActionController::API
 
   private
 
+  def extract_locale_from_accept_language_header
+    if request.env['HTTP_ACCEPT_LANGUAGE']
+      language = request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}(?:-[A-Z]{2})?/).first
+      return language if I18n.available_locales.include?(language&.to_sym)
+    end
+    nil
+  end
+
   def record_not_found(exception)
     model_name = exception.model.constantize.model_name.human
     render json: { error: I18n.t('errors.not_found', model: model_name) }, status: :not_found
+  end
+
+  def render_deletion_message(model_name)
+    render json: { message: I18n.t('default_messages.deleted', model: model_name) }, status: :ok
+  end
+
+  def render_unprocessable_entity_response(exception)
+    render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  def set_locale
+    locale = extract_locale_from_accept_language_header || I18n.default_locale
+    Rails.logger.info "Locale set to #{locale}"
+    I18n.locale = locale
   end
 
   def user_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
     render json: { error: I18n.t("errors.#{policy_name}.#{exception.query}") },
            status: :forbidden
-  end
-
-  def render_unprocessable_entity_response(exception)
-    render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
   end
 
   protected

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -1,0 +1,32 @@
+module ErrorHandler
+    extend ActiveSupport::Concern
+  
+    included do
+      rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+      rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+      rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
+    end
+  
+    private
+  
+    def record_not_found(exception)
+      model_name = exception.model.constantize.model_name.human
+      render json: { error: I18n.t('errors.not_found', model: model_name) }, status: :not_found
+    end
+  
+    def render_deletion_message(model_name)
+      render json: { message: I18n.t('default_messages.deleted', model: model_name) }, status: :ok
+    end
+  
+    def render_unprocessable_entity_response(exception)
+      render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
+    end
+  
+    def user_not_authorized(exception)
+      policy_name = exception.policy.class.to_s.underscore
+      action = exception.query.to_s.chomp('?')
+      model_name = exception.record.class.model_name.human.downcase
+      render json: { error: I18n.t("default_permission_errors.#{action}", model: model_name) }, status: :forbidden
+    end
+  end
+  

--- a/app/controllers/concerns/locale_handler.rb
+++ b/app/controllers/concerns/locale_handler.rb
@@ -1,0 +1,23 @@
+module LocaleHandler
+    extend ActiveSupport::Concern
+  
+    included do
+      before_action :set_locale
+    end
+  
+    private
+  
+    def extract_locale_from_accept_language_header
+      if request.env['HTTP_ACCEPT_LANGUAGE']
+        language = request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}(?:-[A-Z]{2})?/).first
+        return language if I18n.available_locales.include?(language&.to_sym)
+      end
+      nil
+    end
+  
+    def set_locale
+      locale = extract_locale_from_accept_language_header || I18n.default_locale
+      Rails.logger.info "Locale set to #{locale}"
+      I18n.locale = locale
+    end
+  end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,36 +1,42 @@
 class InvoicesController < ApplicationController
   def index
     @invoices = policy_scope(Invoice)
+
     render json: @invoices.map { |invoice| InvoiceSerializer.call(invoice) }
   end
 
   def show
-    @invoice = Invoice.find(params[:id])
-    authorize @invoice
+    authorize invoice
+
     render json: InvoiceSerializer.call(@invoice)
   end
 
   def create
+    authorize Invoice
     @invoice = current_user.invoices.create(invoice_params)
-    authorize @invoice
+
     render json: InvoiceSerializer.call(@invoice), status: :created
   end
 
   def update
-    @invoice = Invoice.find(params[:id])
-    authorize @invoice
+    authorize invoice
     @invoice.update!(invoice_params)
+
     render json: InvoiceSerializer.call(@invoice), status: :ok
   end
 
   def destroy
-    @invoice = Invoice.find(params[:id])
-    authorize @invoice
-    @invoice.destroy
+    authorize invoice
+    invoice.destroy
+
     render_deletion_message('Invoice')
   end
 
   private
+
+  def invoice
+    @invoice = Invoice.find(params[:id])
+  end
 
   def invoice_params
     params.require(:invoice).permit(:invoice_number, :purchase_date, :issue_date, :pdf)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -20,7 +20,7 @@ class InvoicesController < ApplicationController
 
   def update
     authorize invoice
-    @invoice.update!(invoice_params)
+    invoice.update(invoice_params)
 
     render json: InvoiceSerializer.call(@invoice), status: :ok
   end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,5 +1,4 @@
 class InvoicesController < ApplicationController
-
   def index
     @invoices = policy_scope(Invoice)
     render json: @invoices.map { |invoice| InvoiceSerializer.call(invoice) }
@@ -22,6 +21,13 @@ class InvoicesController < ApplicationController
     authorize @invoice
     @invoice.update!(invoice_params)
     render json: InvoiceSerializer.call(@invoice), status: :ok
+  end
+
+  def destroy
+    @invoice = Invoice.find(params[:id])
+    authorize @invoice
+    @invoice.destroy
+    render_deletion_message('Invoice')
   end
 
   private

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ApplicationPolicy
   attr_reader :user, :record
 
@@ -43,7 +41,7 @@ class ApplicationPolicy
     end
 
     def resolve
-      raise NoMethodError, "You must define #resolve in #{self.class}"
+      scope.all
     end
 
     private

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -1,31 +1,36 @@
 class InvoicePolicy < ApplicationPolicy
-  class Scope < Scope
-    def resolve
-      if user.admin?
-        scope.all
-      else
-        scope.where(user_id: user.id)
+    class Scope < Scope
+      def resolve
+        if user.admin?
+          scope.all
+        else
+          scope.where(user_id: user.id)
+        end
       end
     end
-  end
-
-  def index?
-    user.admin?
-  end
-
-  def show?
-    user.admin? || record.user_id == user.id
-  end
-
-  def create?
-    user.present?
-  end
-
-  def update?
-    if user.admin?
-      true
-    else
-      user.role == 'user' && record.user_id == user.id
+  
+    def index?
+      user.admin?
+    end
+  
+    def show?
+      user.admin? || record.user_id == user.id
+    end
+  
+    def create?
+      user.present?
+    end
+  
+    def update?
+      user.admin? || (user.role == 'user' && record.user_id == user.id)
+    end
+  
+    def destroy?
+      user.admin? || record.user_id == user.id
+    end
+  
+    def permitted_attributes
+      [:id, :invoice_number, :purchase_date, :issue_date, :pdf_url]
     end
   end
-end
+  

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,8 @@ module WarrantyManager
     config.api_only = true
     config.middleware.use ActionDispatch::Session::CookieStore, key: '_warranty_manager_session'
 
+    # Internationalization (I18n) Configuration
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = [:en, :'pt-BR']
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,22 +30,26 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+
+  default_messages:
+    deleted: "%{model} deleted."
+
+  default_permission_errors:
+    show: "You do not have permission to view this %{model}."
+    update: "You do not have permission to update this %{model}."
+    create: "You do not have permission to create this %{model}."
+    destroy: "You do not have permission to delete this %{model}."
 
   errors:
-    not_found: "%{model} not found"  
+    not_found: "%{model} not found."
     user_policy:
       index?: "You do not have permission to view all users"
       show?: "You do not have permission to view this user."
       update?: "You do not have permission to update this user."
       create?: "You do not have permission to create this user."
-      destroy?: "You do not have permission to delete this user."
+      destroy?: "You do not have permission to delete this user." 
 
-    invoice_policy:
-      show?: "You do not have permission to view this invoice."
-      update?: "You do not have permission to update this invoice."
-      create?: "You do not have permission to create this invoice."
-      destroy?: "You do not have permission to delete this invoice."
+  hello: "Hello world!"
 
   seed:
     users:
@@ -54,9 +58,8 @@ en:
     invoices:
       success: "Invoice '%{invoice_number}' created successfully!"
       already_exists: "Invoice '%{invoice_number}' already exists."
-      error: "Error creating invoice: %{message}"
+      error: "Error creating invoice: %{message}."
     stores:
       success: "Store '%{name}' created successfully!"
       already_exists: "Store '%{name}' already exists."
       error: "Error creating Store: %{message}"
-  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,4 +62,4 @@ en:
     stores:
       success: "Store '%{name}' created successfully!"
       already_exists: "Store '%{name}' already exists."
-      error: "Error creating Store: %{message}"
+      error: "Error creating Store: %{message}."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -13,10 +13,10 @@ pt-BR:
     not_found: "%{model} não encontrado(a)."
     user_policy:
       index?: "Você não tem permissão para ver os usuários"
-      show?: "Você não tem permissão para visualizar esta invoice."
-      update?: "Você não tem permissão para atualizar esta invoice."
-      create?: "Você não tem permissão para criar esta invoice."
-      destroy?: "Você não tem permissão para excluir esta invoice."
+      show?: "Você não tem permissão para visualizar este usuário."
+      update?: "Você não tem permissão para atualizar este usuário."
+      create?: "Você não tem permissão para criar este usuário."
+      destroy?: "Você não tem permissão para excluir este usuário."
 
   hello: "Olá mundo!"
 
@@ -27,4 +27,8 @@ pt-BR:
     invoices:
       success: "Invoice '%{invoice_number}' criada com sucesso!"
       already_exists: "Invoice '%{invoice_number}' já existe."
-      error: "Erro ao criar invoice: %{message}"
+      error: "Erro ao criar invoice: %{message}."
+    stores:
+      success: "Loja '%{name}' criada com sucesso!"
+      already_exists: "A loja '%{name}' já existe."
+      error: "Erro ao criar a loja: %{message}."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,35 +1,25 @@
 pt-BR:
-  hello: "Olá mundo"
+
+  default_messages:
+    deleted: "%{model} excluido(a)."
+
+  default_permission_errors:
+    show: "Você não tem permissão para ver este(a) %{model}."
+    update: "Você não tem permissão para atualizar este(a) %{model}."
+    create: "Você não tem permissão para criar este(a) %{model}."
+    destroy: "Você não tem permissão para excluir este(a) %{model}."
 
   errors:
-    not_found: "%{model} não encontrado"
+    not_found: "%{model} não encontrado(a)."
     user_policy:
       index?: "Você não tem permissão para ver os usuários"
       show?: "Você não tem permissão para visualizar esta invoice."
       update?: "Você não tem permissão para atualizar esta invoice."
       create?: "Você não tem permissão para criar esta invoice."
       destroy?: "Você não tem permissão para excluir esta invoice."
-  
-  seed:
-    users:
-      success: "Usuário com e-mail '%{email}' criado com sucesso!"
-      already_exists: "Usuário com e-mail '%{email}' já existe."
-    invoices:
-      success: "Invoice '%{invoice_number}' criada com sucesso!"
-      already_exists: "Invoice '%{invoice_number}' já existe."
-      error: "Erro ao criar invoice: %{message}"
-  pt-BR:
-  hello: "Olá mundo"
 
-  errors:
-    not_found: "%{model} não encontrado"
+  hello: "Olá mundo!"
 
-    invoice_policy:
-      show?: "Você não tem permissão para visualizar esta invoice."
-      update?: "Você não tem permissão para atualizar esta invoice."
-      create?: "Você não tem permissão para criar esta invoice."
-      destroy?: "Você não tem permissão para excluir esta invoice."
-      
   seed:
     users:
       success: "Usuário com e-mail '%{email}' criado com sucesso!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
 
-  resources :invoices, only: [:index, :show, :create, :update]
+  resources :invoices, only: [:index, :show, :create, :update, :destroy]
   resources :warranties, only: [:index, :show]
   resources :users, only: [:index, :show, :create, :update]
   resources :stores, only: [:index, :show]


### PR DESCRIPTION
# Atualização de Controllers, Políticas, Internacionalização e Rotas

## Descrição
1. **Refatoração do `ApplicationController`**:
   - Adiciona tratamento centralizado de exceções para `RecordNotFound`, `NotAuthorizedError`, e `RecordInvalid`.
   - Suporte à internacionalização (I18n) para mensagens de erro e permissões.

2. **Melhorias no `InvoicesController`**:
   - Implementação de  `destroy`, com autorização Pundit.
   - Ação `destroy` com retorno de mensagem de exclusão.

3. **Implementação de Políticas**:
   - Adiciona `InvoicePolicy` para controle de acesso com base nos perfis dos usuários.

4. **Internacionalização (I18n)**:
   - Mensagens de erro e permissão configuradas para inglês (`en.yml`) e português (`pt-BR.yml`).

5. **Rotas**:
   - Atualização para incluir a ação  `destroy` para `invoices`.

