### PR TITLE
adiciona a gem ransack ao projeto

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ end
 gem 'devise', '~> 4.9'
 
 gem 'devise_token_auth'
+
+gem 'ransack', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,10 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (3.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis-client (0.22.2)
@@ -253,6 +257,7 @@ DEPENDENCIES
   puma (~> 5.6.9)
   pundit (~> 2.4)
   rails (~> 7.0.8, >= 7.0.8.4)
+  ransack (~> 3.0)
   rspec-rails (~> 6.0)
   rubocop
   sidekiq


### PR DESCRIPTION
# Instala a Gem Ransack 

## Descrição

Adiciona a gem [Ransack](https://github.com/activerecord-hackery/ransack) ao projeto permitindo  pesquisas e filtragem avançadas em modelos Active Record. 

## Mudanças Realizadas

- Adicionada a gem `ransack` ao arquivo `Gemfile`:
  ```ruby
  gem 'ransack'
