### PR TITLE
Feature/controller certificate

### DIFF
--- a/app/controllers/warranties_controller.rb
+++ b/app/controllers/warranties_controller.rb
@@ -1,36 +1,75 @@
 class WarrantiesController < ApplicationController
   def index
+
     @warranties = policy_scope(Warranty)
+
     render json: @warranties.map { |warranty| WarrantySerializer.call(warranty) }
+
   end
 
   def show
+
     authorize warranty
+
     render json: WarrantySerializer.call(warranty)
+
   end
 
-  def create
-    @warranty = Warranty.new(permitted_attributes(Warranty.new))
-    authorize @warranty 
+  def create       
+
+    @warranty = Warranty.new(permitted_attributes(Warranty))
+
+    authorize @warranty
+    
     @warranty.save!
+
     render json: WarrantySerializer.call(@warranty), status: :created
   end
 
   def update
+
     authorize warranty
+
     warranty.update!(permitted_attributes(warranty))
+
     render json: { status: 'success', message: 'Garantia atualizada com sucesso', data: warranty }, status: :ok
+
   end
 
   def destroy
+
     authorize warranty
+
     warranty.destroy
+
     render_deletion_message('Warranty')
+
   end
 
   private
 
-  def warranty
-    @warranty ||= Warranty.find(params[:id])
+  def permitted_attributes(klass)
+
+    params.require(:warranty).permit(:product_id, :warranty_number, :issue_date, :expirity_date, :validity_period)
+  
   end
+
+  def warranty
+
+    @warranty ||= Warranty.find(params[:id])
+
+  end
+
+  def render_created(resource)
+
+    render json: WarrantySerializer.call(resource), status: :created
+
+  end
+  
+  def render_errors(resource)
+
+    render json: { errors: resource.errors.full_messages }, status: :unprocessable_entity
+    
+  end
+
 end

--- a/app/controllers/warranties_controller.rb
+++ b/app/controllers/warranties_controller.rb
@@ -1,21 +1,37 @@
 class WarrantiesController < ApplicationController
-
-  # Lista todas as warranties
   def index
-    @warranties = Warranty.all
-    render json: @warranties
+    @warranties = policy_scope(Warranty)
+    render json: @warranties.map { |warranty| WarrantySerializer.call(warranty) }
   end
 
-  # Exibe uma warranty específica
   def show
-    render json: warranty
+    authorize warranty
+    render json: WarrantySerializer.call(warranty)
+  end
+
+  def create
+    authorize warranty
+    @warranty = Warranty.new(permitted_attributes(Warranty.new))
+    @warranty.product = Product.find(params[:product_id])
+    @warranty.save!
+    render json: WarrantySerializer.call(@warranty), status: :created
+  end
+
+  def update
+    authorize warranty
+    warranty.update!(permitted_attributes(warranty))
+    render json: { status: 'success', message: 'Garantia atualizada com sucesso', data: warranty }, status: :ok
+  end
+
+  def destroy
+    authorize warranty
+    warranty.destroy
+    render_deletion_message('Warranty')
   end
 
   private
 
-  def warranty 
+  def warranty
     @warranty ||= Warranty.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Warranty not found' }, status: :not_found
   end
 end

--- a/app/controllers/warranties_controller.rb
+++ b/app/controllers/warranties_controller.rb
@@ -10,9 +10,8 @@ class WarrantiesController < ApplicationController
   end
 
   def create
-    authorize warranty
     @warranty = Warranty.new(permitted_attributes(Warranty.new))
-    @warranty.product = Product.find(params[:product_id])
+    authorize @warranty 
     @warranty.save!
     render json: WarrantySerializer.call(@warranty), status: :created
   end

--- a/app/policies/warranty_policy.rb
+++ b/app/policies/warranty_policy.rb
@@ -1,15 +1,17 @@
 class WarrantyPolicy < ApplicationPolicy
-    # Regra padrão para todos os métodos
+   
     def index?
-      user.admin? || user_has_access_to_product?
+      user.admin? || user_owns_warranty?
     end
   
     def show?
-      user.admin? || user_has_access_to_product?
+      user.admin? || user_owns_warranty?
     end
   
     def create?
-      user.admin? || user_has_access_to_product?
+      return user.admin? if record.is_a?(Class) 
+
+      user.admin? || user_has_access_to_product? 
     end
   
     def update?
@@ -29,26 +31,18 @@ class WarrantyPolicy < ApplicationPolicy
         end
       end
     end
-
-    def permitted_attributes
-      if record.new_record? # Verifica se é uma criação
-        [:warranty_number, :issue_date, :expirity_date, :validity_period, :product_id, :active]
-      else # Se não for criação, é atualização
-        [:warranty_number, :issue_date, :expirity_date, :validity_period, :active]
-      end
-    end
   
     private
   
-    def user_has_access_to_warranty?
-      record.product.invoice.user == user
-    end
   
     def user_owns_warranty?
       record.product.invoice.user == user
     end
   
     def user_has_access_to_product?
-      record.product.present? && record.product.invoice.user == user
+      product = record.product || Product.find_by(id: permitted_attributes(Warranty)[:product_id])
+      product&.invoice&.user == user
     end
-  end
+    
+
+end

--- a/app/policies/warranty_policy.rb
+++ b/app/policies/warranty_policy.rb
@@ -1,0 +1,50 @@
+class WarrantyPolicy < ApplicationPolicy
+    # Regra padrão para todos os métodos
+    def index?
+      true # Permite listar garantias para todos os usuários autenticados
+    end
+  
+    def show?
+      user_has_access_to_warranty?
+    end
+  
+    def create?
+      user.admin? || user_has_access_to_product?
+    end
+  
+    def update?
+      user.admin? || user_owns_warranty?
+    end
+  
+    def destroy?
+      user.admin? || user_owns_warranty?
+    end
+  
+    class Scope < Scope
+      def resolve
+        if user.admin?
+          scope.all
+        else
+          scope.joins(:product).where(products: { user_id: user.id }) 
+        end
+      end
+    end
+  
+    private
+  
+    def user_has_access_to_warranty?
+      # Verifica se o usuário tem acesso à garantia associada ao produto
+      record.product.user == user
+    end
+  
+    def user_owns_warranty?
+      # Garante que o usuário seja dono do produto ao qual a garantia está associada
+      record.product.user == user
+    end
+  
+    def user_has_access_to_product?
+      # Verifica se o usuário tem permissão para acessar o produto relacionado
+      record.product.present? && record.product.user == user
+    end
+  end
+  

--- a/app/serializers/warranty_serializer.rb
+++ b/app/serializers/warranty_serializer.rb
@@ -1,0 +1,17 @@
+class WarrantySerializer
+    def self.call(warranty)
+      {
+        id: warranty.id,
+        warranty_number: warranty.warranty_number,
+        issue_date: warranty.issue_date,
+        expirity_date: warranty.expirity_date,
+        validity_period: warranty.validity_period,
+        product_id: warranty.product_id, # Inclui o ID do produto relacionado
+        product_name: warranty.product.name, # Opcional: Nome do produto (se existir no modelo Product)
+        active: warranty.expirity_date > Time.zone.now, # Indica se a garantia ainda está ativa
+        created_at: warranty.created_at,
+        updated_at: warranty.updated_at
+      }
+    end
+  end
+  

--- a/app/serializers/warranty_serializer.rb
+++ b/app/serializers/warranty_serializer.rb
@@ -6,9 +6,9 @@ class WarrantySerializer
         issue_date: warranty.issue_date,
         expirity_date: warranty.expirity_date,
         validity_period: warranty.validity_period,
-        product_id: warranty.product_id, # Inclui o ID do produto relacionado
-        product_name: warranty.product.name, # Opcional: Nome do produto (se existir no modelo Product)
-        active: warranty.expirity_date > Time.zone.now, # Indica se a garantia ainda está ativa
+        product_id: warranty.product_id,
+        product_name: warranty.product.name, 
+        active: warranty.expirity_date > Time.zone.now, 
         created_at: warranty.created_at,
         updated_at: warranty.updated_at
       }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
 
   resources :invoices, only: [:index, :show, :create, :update, :destroy]
-  resources :warranties, only: [:index, :show]
+  resources :warranties, only: [:index, :show, :create, :update, :destroy]
   resources :users, only: [:index, :show, :create, :update, :destroy]
   resources :stores, only: [:index, :show, :create, :update, :destroy]
   resources :products, only: [:index, :show, :create, :update, :destroy]


### PR DESCRIPTION
### **Alterações realizadas e justificativas para algumas ações:** 
1. Dentro do `warranties_controller`, mais especificamente na `def create`, as alterações e testes foram feitos dentro da função com o `authorize Warranty`, assim chamando uma classe em vez de um objeto, porém sem sucesso na hora do usuário comum conseguir ter permissão em conseguir enviar,  por várias vezes solicitei ajuda à inteligência artificial contudo as orientações citadas pela IA cabia muitas alterações em códigos adjacentes onde poderia haver um compromentimento do código e em consequência de todo o projeto, além de demandar um tempo na qual poderia comprometer a entrega da funcionalidade e apresentações relacionados ao mesmo.
2. Dentro da `warranty_policy` consegui com êxito maior ao modificar o código para que aceitasse tanto uma classe quanto um objeto como observado nas linhas 12.


